### PR TITLE
feat: implement sdcv cli interface for rmall

### DIFF
--- a/scripts/sdcv-adapter
+++ b/scripts/sdcv-adapter
@@ -1,0 +1,128 @@
+#!/usr/bin/env perl
+use v5.12;
+use utf8;
+use warnings;
+use open qw(:std :utf8);
+
+use Getopt::Long;
+use Term::ReadLine;
+
+my %opt = map {
+    s/_/-/gr => undef
+} qw/
+help version
+list_dicts use_dict
+exact_search
+
+non_interactive only_data_dir data_dir
+json utf8_output utf8_input color
+/;
+
+sub help {
+    print <<'eof';
+Usage:
+  sdcv [OPTION…]  words
+
+Help Options:
+  -h, --help                     Show help options
+
+Application Options:
+  -v, --version                  display version information and exit
+  -l, --list-dicts               display list of available dictionaries and exit
+  -u, --use-dict=bookname        for search use only dictionary with this bookname
+  -n, --non-interactive          for use in scripts
+  -j, --json-output              print the result formatted as JSON
+  -e, --exact-search             do not fuzzy-search for similar words, only return exact matches
+  -0, --utf8-output              output must be in utf8
+  -1, --utf8-input               input of sdcv in utf8
+  -2, --data-dir=path/to/dir     use this directory as path to stardict data directory
+  -x, --only-data-dir            only use the dictionaries in data-dir, do not search in user and system directories
+  -c, --color                    colorize the output
+eof
+    exit;
+}
+
+sub version {
+    exec "rmall --version"
+}
+
+sub list_dicts {
+    ...;
+    exit
+}
+
+sub fuzzy_search {
+    if (defined $cfg{use_dict}) {
+        system qw/rmall -L -l/, $cfg{use_dict}, '--', $_ for (@_);
+    } else {
+        system qw/rmall -L --/, $_ for (@_);
+    }
+}
+
+sub full_text_search {
+    if (defined $cfg{use_dict}) {
+        system qw/rmall -L -e -l/, $cfg{use_dict}, '--', $_ for (@_);
+    } else {
+        system qw/rmall -L -e --/, $_ for (@_);
+    }
+}
+
+sub regexp_search {
+    die "not implemented in rmall"
+}
+
+sub search {
+    for (@_) {
+        if (/^[\/]/) {
+            fuzzy_search substr $_, 1
+        } elsif (/^[|]/) {
+            full_text_search substr $_, 1
+        } elsif (/[?*]/) {
+            regexp_search $_
+        } else {
+            fuzzy_search $_
+        }
+    }
+}
+
+sub repl {
+    my $term = Term::ReadLine->new('sdcv');
+    my $prompt = 'Enter word or phrase:';
+    my $out = $term->OUT || \*STDOUT;
+    while (defined ($_ = $term->readline($prompt)) ) {
+        chomp;
+        search $_;
+        $term->addhistory($_) if /\S/;
+    }
+}
+
+GetOptions(
+    'h|help' => \$opt{help},
+    'v|version' => \$opt{version},
+    'l|list-dicts' => \$opt{list_dicts},
+    'e|exact-search' => \$opt{exact_search},
+    'u|use-dict:s' => \$opt{use_dict},
+
+    'n|non-interactive' => \$opt{non_interactive},
+    'x|only-data-dir:s' => \$opt{only_data_dir},
+    'data-dir:s' => \$opt{data_dir},
+    'j|json' => \$opt{json},
+    'utf8-output' => \$opt{utf8_output},
+    'utf8-input' => \$opt{utf8_input},
+    'color' => \$opt{color},
+) or help;
+
+help if defined $opt{help};
+version if defined $opt{version};
+list_dicts if defined $opt{list_dicts};
+
+unless (scalar @ARGV) {
+    exit if defined $opt{non_interactive};
+    repl
+}
+
+if (defined $opt{exact_search}) {
+    full_text_search @ARGV
+} else {
+    search @ARGV
+}


### PR DESCRIPTION
能够将部分 sdcv 的参数翻译成 rmall 的参数。方便旧脚本迁移。

实现的特性：

1. 交互模式、交互模式开关及 readline 支持
2. 根据单词开头是否为 `|` `/` 来决定对该单词使用模糊搜索还是精确搜索
3. 一次查询多个单词
4. 指定所使用的词典

未实现的特性：

1. 列出所有词典
2. 选择词典所在文件夹
3. 基于正则表达式的搜索
4. json 输出

忽略的特性：

1. utf8 输入/输出
2. 基于 ANSI-Escape Sequence 的终端颜色