### PR TITLE
feat: shell completions generator.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ rustyline = "10.1.1"
 dialoguer = "0.10.4"
 tokio = { version = "1.28.2", features = ["rt"] }
 rodio = "0.17.1"
+clap_complete = "4.3.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,7 +1,8 @@
 pub use clap::{Args, Parser};
+use clap_complete::Shell;
 
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None, after_help =
+#[command(author, version, about, long_about = None, bin_name = "rmall", after_help =
 "Examples:
   When no subcommand is specified, the default is 'lookup'.
   you can list all records:
@@ -39,6 +40,10 @@ pub struct Cli {
     /// Read aloud
     #[arg(short, long)]
     pub read_aloud: bool,
+
+    /// generate shell completion scripts
+    #[arg(short, long, value_enum, value_name = "SHELL")]
+    pub completions: Option<Shell>,
 
     pub word: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use clap::CommandFactory;
 use rmall::{
     cli::{Action, Cli, Parser},
     error::Result,
@@ -7,15 +8,33 @@ use rmall::{
 fn main() -> Result<()> {
     let cli: Cli = Cli::parse();
 
+    if let Some(shell) = cli.completions {
+        clap_complete::generate(shell, &mut Cli::command(), "rmall", &mut std::io::stdout());
+        std::process::exit(0);
+    }
+
     if let Some(action) = cli.action {
         match action {
             Action::Count => history::count_history(),
             Action::List(t) => history::list_history(t.type_, t.sort, t.table, t.column),
             Action::Lookup(w) => {
                 if let Some(word) = w.word {
-                    query(w.online, w.local_first, w.exact_search, word, &w.local, w.read_aloud)
+                    query(
+                        w.online,
+                        w.local_first,
+                        w.exact_search,
+                        word,
+                        &w.local,
+                        w.read_aloud,
+                    )
                 } else if !w.non_interactive {
-                    repl(w.online, w.local_first, w.exact_search, &w.local, w.read_aloud)
+                    repl(
+                        w.online,
+                        w.local_first,
+                        w.exact_search,
+                        &w.local,
+                        w.read_aloud,
+                    )
                 } else {
                     Ok(())
                 }
@@ -29,10 +48,16 @@ fn main() -> Result<()> {
             cli.exact_search,
             word,
             &cli.local,
-            cli.read_aloud
+            cli.read_aloud,
         )
     } else if !cli.non_interactive {
-        repl(cli.online, cli.local_first, cli.exact_search, &cli.local, cli.read_aloud)
+        repl(
+            cli.online,
+            cli.local_first,
+            cli.exact_search,
+            &cli.local,
+            cli.read_aloud,
+        )
     } else {
         Ok(())
     }


### PR DESCRIPTION
user can now generate shell completion scripts for rmall by running `rmall -c <SHELL>`. for example, `rmall -c bash` generates a script which provides command-line options completions for bash.